### PR TITLE
add "/document all_packages" command

### DIFF
--- a/.github/workflows/styler-actions.yml
+++ b/.github/workflows/styler-actions.yml
@@ -53,12 +53,19 @@ jobs:
         run: Rscript scripts/generate_dependencies.R
       - id: file_changes
         uses: trilom/file-changes-action@v1.2.3
+      - id: doc_all
+        if: startsWith(github.event.comment.body, '/document all_packages')
+        shell: bash
+        run: |
+          DESCS=$(find . -name DESCRIPTION | tr '\n' ' ')
+          echo "::set-output name=descriptions::${DESCS}"
       - name : make
         shell: bash
         env:
           FILES: ${{ join(fromJSON(steps.file_changes.outputs.files_modified), ' ') }}
+          EXTRA_FILES: ${{ steps.doc_all.outputs.descriptions }}
         run: |
-          echo ${FILES} \
+          echo ${FILES} ${EXTRA_FILES} \
           | tr ' ' '\n' \
           | grep -e base -e models -e modules \
           | cut -d / -f 1-2 \


### PR DESCRIPTION
Only needed to because I wanted to redocument all of PEcAn,
using a new version of Roxygen,
AND doing it on GitHub instead of locally.
In all most other cases `document all_packages` will produce
identical results to `/document` but will take longer to do it.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Please select appropriate Priority, Status,and Type labels-->
<!--- If you do not have permission to select labels please state which labels you would like -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ ] When possible
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
